### PR TITLE
feat: assign version to SerializationFeature.Float16Array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
-Nothing yet.
+### Added
+
+- Marked SerializationFeature.Float16Array as released from V8 13.1.201 (was
+  marked as unreleased).
 
 ## [0.1.0] - 2024-09-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to v8serialize will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+Nothing yet.
+
+## [0.1.0] - 2024-09-24
+
+### Added
+
+- The first stable release.
+
+[unreleased]: https://github.com/h4l/v8serialize/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/h4l/v8serialize/releases/tag/v0.1.0

--- a/src/v8serialize/constants.py
+++ b/src/v8serialize/constants.py
@@ -547,7 +547,7 @@ https://github.com/v8/v8/commit/5ff265b202a593d7f45348c2a3f0d4dd5fdff74e)
     if this happens.
     """
 
-    Float16Array = 8, SymbolicVersion.Unreleased
+    Float16Array = 8, "13.1.201"
     """
     Support for encoding typed array views holding Float16 elements.
 

--- a/test/test_constants.py
+++ b/test/test_constants.py
@@ -134,11 +134,7 @@ def test_SerializationFeature__for_name() -> None:
         (Version("10.6.0"), SerializationFeature.MaxCompatibility),
         (Version("10.7.123"), SerializationFeature.RegExpUnicodeSets),
         ("10.7.123", SerializationFeature.RegExpUnicodeSets),
-        (
-            Version("15.0.0"),
-            # Float16Array cannot be included as its version is not released
-            ~SerializationFeature.Float16Array,
-        ),
+        (Version("13.1.201"), ~SerializationFeature.MaxCompatibility),
         (SymbolicVersion.Unreleased, ~SerializationFeature.MaxCompatibility),
     ],
 )


### PR DESCRIPTION
It was marked as unreleased, but the feature was released in V8 version 13.1.201.