### PR TITLE
build(ci): ensure echoserver healthy before testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  ECHOSERVER_VERSION: 0.2.0
+  ECHOSERVER_VERSION: 0.3.0
 
 jobs:
   prepare_checks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,9 +28,12 @@ services:
     environment:
       V8SERIALIZE_ECHOSERVERS: "${V8SERIALIZE_ECHOSERVERS:-__required_but_not_set__}"
     depends_on:
-      - echoserver-node-22
-      - echoserver-node-18
-      - echoserver-deno
+      echoserver-node-22:
+        condition: service_healthy
+      echoserver-node-18:
+        condition: service_healthy
+      echoserver-deno:
+        condition: service_healthy
     command: pytest -m integration -vv
     volumes:
       - .:${WORKSPACE_MOUNT_PATH:-/workspace}


### PR DESCRIPTION
The integration tests now wait for the echoserver containers to be healthy before running. This should avoid tests failing due to failing to connect to the echoserver(s) while they're starting.

For example: https://github.com/h4l/v8serialize/actions/runs/12533338515/job/34952929385