### PR TITLE
feat: add JSBigInt type and formalise number encoding/decoding rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 
 - Marked SerializationFeature.Float16Array as released from V8 13.1.201 (was
   marked as unreleased). ([#3](https://github.com/h4l/v8serialize/pull/3))
+- `JSBigInt` type — a Python `int` subclass that always encodes to BigInt.
+  ([#7](https://github.com/h4l/v8serialize/pull/7))
 
 ### Changed
 
@@ -19,6 +21,46 @@ and this project adheres to
   Previously types were only shown in the table of parameters. Overloaded
   functions with multiple signatures are not shown, only the catch-all signature
   is (this is a limitation of quartodoc).
+  ([#6](https://github.com/h4l/v8serialize/pull/6))
+- Adjust number encoding rules.
+
+  - The JSBigInt type added in this release always encodes to JavaScript bigint,
+    and serialized bigints always decode to JSBigInt.
+    - Previously bigint decoded to plain `int`, which meant that bigints in the
+      safe float range would not round-trip as bigint, they'd be encoded as one
+      of the int types, like Int32, or Double.
+  - JavaScript Numbers encoded as Double (float64) now decode to Python `int` if
+    they are exact integers in the range of integers that float64 can represent
+    exactly.
+    - Previously JavaScript Numbers that weren't serialized as one of the int
+      types (like Int32) were always decoded as Python `float`.
+
+  The encoding rules now are:
+
+  - Python `float` always encodes to Double/float64.
+  - Python `int` encodes to Double/float64 if it's within the float-safe range
+    but too large for the int types, like Int32.
+  - Python `int` encodes to JavaScript bigint if it's outside than the
+    float-safe range.
+  - Python `JSBigInt` always encodes to JavaScript bigint.
+
+  The decoding rules now are:
+
+  - JavaScript Double/float64 decodes to Python `float`, unless it's an exact
+    integer within the float-safe integer range, in which case it decodes as
+    Python `int`.
+  - Small int values like Int32 decode as Python `int`.
+  - JavaScript bigint values decode as Python `JSBigInt`.
+
+  So values round-trip with the same types consistently, with the exceptions of:
+
+  - large Python `int` which becomes `JSBigInt` after a round-trip.
+  - exact integer Python `float` round-trip to Python `int`
+    - This is compatible with Python's numeric type system as `int` types are
+      accepted by types requiring `float`, and the `/` and `//` operators work
+      equivalently with `int` and `float` representations of the same value.
+
+  ([#7](https://github.com/h4l/v8serialize/pull/7))
 
 ## [0.1.0] - 2024-09-24
 

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -275,6 +275,7 @@ quartodoc:
           contents:
             - jstypes.JSUndefined
             - jstypes.JSPrimitiveObject
+            - jstypes.PrimitiveObjectValue
         - kind: page
           path: "javascript_regexp"
           summary:
@@ -341,6 +342,7 @@ quartodoc:
             - constants.JS_CONSTANT_TAGS
             - constants.JS_ARRAY_BUFFER_TAGS
             - constants.JS_PRIMITIVE_OBJECT_TAGS
+            - constants.PrimitiveObjectTag
             - constants.JS_STRING_TAGS
 
     - title: HostObject Extensions

--- a/src/v8serialize/constants.py
+++ b/src/v8serialize/constants.py
@@ -668,6 +668,29 @@ class TagConstraint(FrozenAfterInitDataclass, Generic[TagT_co]):
         return f"{self.name}: {self.allowed_tag_names}"
 
 
+NumberTag = Literal[
+    SerializationTag.kInt32,
+    SerializationTag.kDouble,
+    SerializationTag.kUint32,
+    SerializationTag.kNumberObject,
+]
+
+JS_NUMBER_TAGS: Final = TagConstraint[NumberTag](
+    name="JavaScript Numbers",
+    allowed_tags=frozenset(
+        {
+            SerializationTag.kInt32,
+            SerializationTag.kDouble,
+            SerializationTag.kUint32,
+            SerializationTag.kNumberObject,
+        }
+    ),
+)
+"""Tags that are allowed in the context of a JavaScript Number value.
+
+Does not include JavaScript bigint.
+"""
+
 ObjectKeyTag = Literal[
     SerializationTag.kInt32,
     SerializationTag.kDouble,

--- a/src/v8serialize/constants.py
+++ b/src/v8serialize/constants.py
@@ -761,13 +761,19 @@ JS_ARRAY_BUFFER_TAGS: Final = TagConstraint[ArrayBufferTags](
     ),
 )
 
-PrimitiveObjectTag = Literal[
+PrimitiveObjectTag: TypeAlias = Literal[
     SerializationTag.kTrueObject,
     SerializationTag.kFalseObject,
     SerializationTag.kNumberObject,
     SerializationTag.kBigIntObject,
     SerializationTag.kStringObject,
 ]
+"""
+The type of the [SerializationTag] values in [JS_PRIMITIVE_OBJECT_TAGS]
+
+[JS_PRIMITIVE_OBJECT_TAGS]: `v8serialize.constants.JS_PRIMITIVE_OBJECT_TAGS`
+[SerializationTag]: `v8serialize.constants.SerializationTag`
+"""
 
 JS_PRIMITIVE_OBJECT_TAGS = TagConstraint[PrimitiveObjectTag](
     name="Primitive wrapper objects",
@@ -781,6 +787,13 @@ JS_PRIMITIVE_OBJECT_TAGS = TagConstraint[PrimitiveObjectTag](
         }
     ),
 )
+"""
+[SerializationTag] values that represent wrapped primitive values.
+
+These are primitive values wrapped in an object on the heap.
+
+[SerializationTag]: `v8serialize.constants.SerializationTag`
+"""
 
 StringTag = Literal[
     SerializationTag.kUtf8String,

--- a/src/v8serialize/decode.py
+++ b/src/v8serialize/decode.py
@@ -78,6 +78,7 @@ from v8serialize.extensions import NodeJsArrayBufferViewHostObjectHandler
 from v8serialize.jstypes import JSHole, JSObject, JSUndefined
 from v8serialize.jstypes._v8 import V8SharedObjectReference, V8SharedValueId
 from v8serialize.jstypes.jsarray import JSArray
+from v8serialize.jstypes.jsbigint import JSBigInt
 from v8serialize.jstypes.jsbuffers import (
     JSArrayBuffer,
     JSArrayBufferTransfer,
@@ -391,7 +392,8 @@ class ReadableTagStream:
             result = JSPrimitiveObject(self.read_double(tag=False))
         elif tag is SerializationTag.kBigIntObject:
             result = JSPrimitiveObject(
-                self.read_bigint(tag=False), tag=SerializationTag.kBigIntObject
+                JSBigInt(self.read_bigint(tag=False)),
+                tag=SerializationTag.kBigIntObject,
             )
         elif tag is SerializationTag.kStringObject:
             result = JSPrimitiveObject(self.read_string_utf8(tag=False))
@@ -1204,7 +1206,6 @@ class TagReader(DecodeStepObject):
         r(SerializationTag.kOneByteString, read_stream(ReadableTagStream.read_string_onebyte))  # noqa: E501
         r(SerializationTag.kTwoByteString, read_stream(ReadableTagStream.read_string_twobyte))  # noqa: E501
         r(SerializationTag.kUtf8String, read_stream(ReadableTagStream.read_string_utf8))
-        r(SerializationTag.kBigInt, read_stream(ReadableTagStream.read_bigint))
         r(SerializationTag.kInt32, read_stream(ReadableTagStream.read_int32))
         r(SerializationTag.kUint32, read_stream(ReadableTagStream.read_uint32))
 
@@ -1226,6 +1227,7 @@ class TagReader(DecodeStepObject):
         r(SerializationTag.kWasmModuleTransfer, TagReader.deserialize_unsupported_wasm)
         r(SerializationTag.kWasmMemoryTransfer, TagReader.deserialize_unsupported_wasm)
         r(SerializationTag.kHostObject, TagReader.deserialize_host_object)
+        r(SerializationTag.kBigInt, TagReader.deserialize_js_bigint)
 
         # fmt: on
 
@@ -1411,6 +1413,11 @@ class TagReader(DecodeStepObject):
         self, tag: Literal[SerializationTag.kDate], ctx: DecodeContext
     ) -> datetime:
         return ctx.stream.read_js_date(tz=self.default_timezone).object
+
+    def deserialize_js_bigint(
+        self, tag: Literal[SerializationTag.kBigInt], ctx: DecodeContext
+    ) -> JSBigInt:
+        return JSBigInt(ctx.stream.read_bigint())
 
 
 default_decode_steps: Final[Sequence[DecodeStep]] = (TagReader(),)

--- a/src/v8serialize/decode.py
+++ b/src/v8serialize/decode.py
@@ -54,6 +54,7 @@ from v8serialize._values import (
 from v8serialize._values import SharedArrayBufferId as SharedArrayBufferId
 from v8serialize._values import TransferId as TransferId
 from v8serialize.constants import (
+    FLOAT64_SAFE_INT_RANGE,
     INT32_RANGE,
     JS_ARRAY_BUFFER_TAGS,
     JS_CONSTANT_TAGS,
@@ -1202,7 +1203,6 @@ class TagReader(DecodeStepObject):
         # fmt: off
 
         # primitives — just read the stream directly, no handling needed
-        r(SerializationTag.kDouble, read_stream(ReadableTagStream.read_double))
         r(SerializationTag.kOneByteString, read_stream(ReadableTagStream.read_string_onebyte))  # noqa: E501
         r(SerializationTag.kTwoByteString, read_stream(ReadableTagStream.read_string_twobyte))  # noqa: E501
         r(SerializationTag.kUtf8String, read_stream(ReadableTagStream.read_string_utf8))
@@ -1228,6 +1228,7 @@ class TagReader(DecodeStepObject):
         r(SerializationTag.kWasmMemoryTransfer, TagReader.deserialize_unsupported_wasm)
         r(SerializationTag.kHostObject, TagReader.deserialize_host_object)
         r(SerializationTag.kBigInt, TagReader.deserialize_js_bigint)
+        r(SerializationTag.kDouble, TagReader.deserialize_js_double)
 
         # fmt: on
 
@@ -1418,6 +1419,14 @@ class TagReader(DecodeStepObject):
         self, tag: Literal[SerializationTag.kBigInt], ctx: DecodeContext
     ) -> JSBigInt:
         return JSBigInt(ctx.stream.read_bigint())
+
+    def deserialize_js_double(
+        self, tag: Literal[SerializationTag.kDouble], ctx: DecodeContext
+    ) -> int | float:
+        value = ctx.stream.read_double()
+        if value.is_integer() and (intval := int(value)) in FLOAT64_SAFE_INT_RANGE:
+            return intval
+        return value
 
 
 default_decode_steps: Final[Sequence[DecodeStep]] = (TagReader(),)

--- a/src/v8serialize/encode.py
+++ b/src/v8serialize/encode.py
@@ -63,6 +63,7 @@ from v8serialize.jstypes import JSObject
 from v8serialize.jstypes._v8 import V8SharedObjectReference
 from v8serialize.jstypes.jsarray import JSArray
 from v8serialize.jstypes.jsarrayproperties import JSHoleEnum, JSHoleType
+from v8serialize.jstypes.jsbigint import JSBigInt
 from v8serialize.jstypes.jsbuffers import (
     BaseJSArrayBuffer,
     JSArrayBuffer,
@@ -882,11 +883,17 @@ class TagWriter(EncodeStepObject):
         elif value in FLOAT64_SAFE_INT_RANGE:
             ctx.stream.write_double(value)
         else:
-            # Can't use bigints for object keys, so write large ints as strings
-            if ctx.stream.allowed_tags is JS_OBJECT_KEY_TAGS:
-                ctx.stream.write_string_onebyte(str(value))  # onebyte always OK for int
-            else:
-                ctx.stream.write_bigint(value)
+            self.serialize_bigint(value, ctx, next)
+
+    @encode.register(JSBigInt)
+    def serialize_bigint(
+        self, value: int, /, ctx: EncodeContext, next: EncodeNextFn
+    ) -> None:
+        # Can't use bigints for object keys, so write large ints as strings
+        if ctx.stream.allowed_tags is JS_OBJECT_KEY_TAGS:
+            ctx.stream.write_string_onebyte(str(value))  # onebyte always OK for int
+        else:
+            ctx.stream.write_bigint(value)
 
     @encode.register(JSHoleEnum)
     def serialize_hole(

--- a/src/v8serialize/jstypes/__init__.py
+++ b/src/v8serialize/jstypes/__init__.py
@@ -14,6 +14,7 @@ from v8serialize.jstypes._repr import js_repr_settings as js_repr_settings
 from v8serialize.jstypes.jsarray import JSArray as JSArray
 from v8serialize.jstypes.jsarrayproperties import JSHole as JSHole
 from v8serialize.jstypes.jsarrayproperties import JSHoleType as JSHoleType
+from v8serialize.jstypes.jsbigint import JSBigInt as JSBigInt
 from v8serialize.jstypes.jsbuffers import (
     ArrayBufferViewStructFormat as ArrayBufferViewStructFormat,
 )

--- a/src/v8serialize/jstypes/__init__.py
+++ b/src/v8serialize/jstypes/__init__.py
@@ -53,7 +53,25 @@ from v8serialize.jstypes.jserror import JSError as JSError
 from v8serialize.jstypes.jserror import JSErrorData as JSErrorData
 from v8serialize.jstypes.jsmap import JSMap as JSMap
 from v8serialize.jstypes.jsobject import JSObject as JSObject
+from v8serialize.jstypes.jsprimitiveobject import (
+    FalseJSPrimitiveObject as FalseJSPrimitiveObject,
+)
 from v8serialize.jstypes.jsprimitiveobject import JSPrimitiveObject as JSPrimitiveObject
+from v8serialize.jstypes.jsprimitiveobject import (
+    NumberJSPrimitiveObject as NumberJSPrimitiveObject,
+)
+from v8serialize.jstypes.jsprimitiveobject import (
+    PrimitiveObjectValue as PrimitiveObjectValue,
+)
+from v8serialize.jstypes.jsprimitiveobject import (
+    StringJSPrimitiveObject as StringJSPrimitiveObject,
+)
+from v8serialize.jstypes.jsprimitiveobject import (
+    TrueJSPrimitiveObject as TrueJSPrimitiveObject,
+)
+from v8serialize.jstypes.jsprimitiveobject import (
+    UnknownJSPrimitiveObject as UnknownJSPrimitiveObject,
+)
 from v8serialize.jstypes.jsregexp import JSRegExp as JSRegExp
 from v8serialize.jstypes.jsset import JSSet as JSSet
 from v8serialize.jstypes.jsundefined import JSUndefined as JSUndefined

--- a/src/v8serialize/jstypes/jsbigint.py
+++ b/src/v8serialize/jstypes/jsbigint.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
+
+if TYPE_CHECKING:
+    from typing_extensions import Self, SupportsIndex, TypeAlias
+
+    # https://github.com/python/typeshed/blob/main/stdlib/builtins.pyi
+    # fmt: off
+    _PositiveInteger: TypeAlias = Literal[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]  # noqa: E501
+    _NegativeInteger: TypeAlias = Literal[-1, -2, -3, -4, -5, -6, -7, -8, -9, -10, -11, -12, -13, -14, -15, -16, -17, -18, -19, -20]  # noqa: E501
+    # fmt: on
+
+    T = TypeVar("T")
+
+
+class JSBigInt(int):
+    """A Python `int` subtype that represents JavaScript bigint values."""
+
+    __slots__ = ()
+
+    @overload
+    def _wrap_int(self, value: int) -> Self: ...
+    @overload
+    def _wrap_int(self, value: T) -> T: ...
+    def _wrap_int(self, value: object) -> object:
+        if isinstance(value, int):
+            return self.__class__(value)
+        return value
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({super().__repr__()})"
+
+    # Override all the int-returning methods defined in typeshed for int. (Other
+    # than methods that return an int incidentally, such as bit_length().)
+    # https://github.com/python/typeshed/blob/main/stdlib/builtins.pyi
+
+    def as_integer_ratio(self) -> tuple[Self, Self]:  # type: ignore[override]
+        return self, self.__class__(1)
+
+    @property
+    def real(self) -> Self:
+        return self
+
+    @property  # type: ignore[override]
+    def imag(self) -> Self:
+        return self.__class__(0)
+
+    @property
+    def numerator(self) -> Self:
+        return self
+
+    @property  # type: ignore[override]
+    def denominator(self) -> Self:
+        return self.__class__(1)
+
+    def conjugate(self) -> Self:
+        return self
+
+    def __add__(self, value: int, /) -> Self:
+        return self._wrap_int(super().__add__(value))
+
+    def __sub__(self, value: int, /) -> Self:
+        return self._wrap_int(super().__sub__(value))
+
+    def __mul__(self, value: int, /) -> Self:
+        return self._wrap_int(super().__mul__(value))
+
+    def __floordiv__(self, value: int, /) -> Self:
+        return self._wrap_int(super().__floordiv__(value))
+
+    # def __truediv__(self, value: int, /) -> float: ...
+
+    def __mod__(self, value: int, /) -> Self:
+        return self._wrap_int(super().__mod__(value))
+
+    def __divmod__(self, value: int, /) -> tuple[Self, Self]:
+        result = super().__divmod__(value)
+        if result is NotImplemented:
+            return NotImplemented
+        return self.__class__(result[0]), self.__class__(result[1])
+
+    def __radd__(self, value: int, /) -> Self:
+        return self._wrap_int(super().__radd__(value))
+
+    def __rsub__(self, value: int, /) -> Self:
+        return self._wrap_int(super().__rsub__(value))
+
+    def __rmul__(self, value: int, /) -> Self:
+        return self._wrap_int(super().__rmul__(value))
+
+    def __rfloordiv__(self, value: int, /) -> Self:
+        return self._wrap_int(super().__rfloordiv__(value))
+
+    # def __rtruediv__(self, value: int, /) -> float: ...
+
+    def __rmod__(self, value: int, /) -> Self:
+        return self._wrap_int(super().__rmod__(value))
+
+    def __rdivmod__(self, value: int, /) -> tuple[Self, Self]:
+        result = super().__rdivmod__(value)
+        if result is NotImplemented:
+            return NotImplemented  # type: ignore[no-any-return]
+        return self.__class__(result[0]), self.__class__(result[1])
+
+    @overload  # type: ignore[override]
+    def __pow__(self, value: _PositiveInteger, mod: None = None, /) -> Self: ...
+    @overload
+    def __pow__(self, value: _NegativeInteger, mod: None = None, /) -> float: ...
+    # # positive __value -> int; negative __value -> float
+    # # return type must be Any as `int | float` causes too many false-positive errors
+    @overload
+    def __pow__(self, value: int, mod: None = None, /) -> Any: ...
+    @overload
+    def __pow__(self, value: int, mod: int, /) -> int: ...
+    def __pow__(self, value: int, mod: int | None = None, /) -> Any:
+        return self._wrap_int(super().__pow__(value, mod))
+
+    def __rpow__(self, value: int, mod: int | None = None, /) -> Any:
+        return self._wrap_int(super().__rpow__(value, mod))
+
+    def __and__(self, value: int, /) -> Self:
+        return self._wrap_int(super().__and__(value))
+
+    def __or__(self, value: int, /) -> Self:
+        return self._wrap_int(super().__or__(value))
+
+    def __xor__(self, value: int, /) -> Self:
+        return self._wrap_int(super().__xor__(value))
+
+    def __lshift__(self, value: int, /) -> Self:
+        return self._wrap_int(super().__lshift__(value))
+
+    def __rshift__(self, value: int, /) -> Self:
+        return self._wrap_int(super().__rshift__(value))
+
+    def __rand__(self, value: int, /) -> Self:
+        return self._wrap_int(super().__rand__(value))
+
+    def __ror__(self, value: int, /) -> Self:
+        return self._wrap_int(super().__ror__(value))
+
+    def __rxor__(self, value: int, /) -> Self:
+        return self._wrap_int(super().__rxor__(value))
+
+    def __rlshift__(self, value: int, /) -> Self:
+        return self._wrap_int(super().__rlshift__(value))
+
+    def __rrshift__(self, value: int, /) -> Self:
+        return self._wrap_int(super().__rrshift__(value))
+
+    def __neg__(self) -> Self:
+        return self._wrap_int(super().__neg__())
+
+    def __pos__(self) -> Self:
+        return self._wrap_int(super().__pos__())
+
+    def __invert__(self) -> Self:
+        return self._wrap_int(super().__invert__())
+
+    def __trunc__(self) -> Self:
+        return self._wrap_int(super().__trunc__())
+
+    def __ceil__(self) -> Self:
+        return self._wrap_int(super().__ceil__())
+
+    def __floor__(self) -> Self:
+        return self._wrap_int(super().__floor__())
+
+    def __round__(self, ndigits: SupportsIndex = 0, /) -> Self:
+        return self._wrap_int(super().__round__(ndigits))
+
+    # def __getnewargs__(self) -> tuple[int]: ...
+    # def __eq__(self, value: object, /) -> bool: ...
+    # def __ne__(self, value: object, /) -> bool: ...
+    # def __lt__(self, value: int, /) -> bool: ...
+    # def __le__(self, value: int, /) -> bool: ...
+    # def __gt__(self, value: int, /) -> bool: ...
+    # def __ge__(self, value: int, /) -> bool: ...
+    # def __float__(self) -> float: ...
+    # def __int__(self) -> int: ...
+    def __abs__(self) -> Self:
+        return self._wrap_int(super().__abs__())
+
+    # def __hash__(self) -> int: ...
+    # def __bool__(self) -> bool: ...
+    # def __index__(self) -> int: ...

--- a/src/v8serialize/jstypes/jsprimitiveobject.py
+++ b/src/v8serialize/jstypes/jsprimitiveobject.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABCMeta
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Generic
+from typing import TYPE_CHECKING, Final, Generic, Literal, Union, overload
 
 from v8serialize._pycompat.dataclasses import slots_if310
 from v8serialize.constants import (
@@ -10,21 +10,36 @@ from v8serialize.constants import (
     PrimitiveObjectTag,
     SerializationTag,
 )
+from v8serialize.jstypes.jsbigint import JSBigInt
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
+PrimitiveObjectValue: TypeAlias = Union[float, bool, JSBigInt, str]
+"""
+The types that can be wrapped in a [JSPrimitiveObject].
+
+[JSPrimitiveObject]: `v8serialize.jstypes.JSPrimitiveObject`
+"""
 
 if TYPE_CHECKING:
     from typing_extensions import TypeVar
 
-    T = TypeVar(
-        "T", bound="float | bool | int | str", default="float | bool | int | str"
+    T_co = TypeVar(
+        "T_co", bound=PrimitiveObjectValue, default=PrimitiveObjectValue, covariant=True
+    )
+    TagT_co = TypeVar(
+        "TagT_co", bound=PrimitiveObjectTag, default=PrimitiveObjectTag, covariant=True
     )
 else:
     from typing import TypeVar
 
-    T = TypeVar("T", bound="float | bool | int | str")
+    T_co = TypeVar("T_co", bound=PrimitiveObjectValue)
+    TagT_co = TypeVar("TagT_co", bound=PrimitiveObjectTag)
 
 
 @dataclass(frozen=True, order=True, init=False, **slots_if310())
-class JSPrimitiveObject(Generic[T], metaclass=ABCMeta):
+class JSPrimitiveObject(Generic[T_co, TagT_co], metaclass=ABCMeta):
     """
     Python equivalent of a wrapped/boxed JavaScript primitive.
 
@@ -49,43 +64,204 @@ class JSPrimitiveObject(Generic[T], metaclass=ABCMeta):
         times in a V8 serialized data stream. This could be used to de-duplicate
         strings or bigints.
     * It allows data streams to be round-tripped exactly.
+
+    ---
+    Each `tag` has a single `value` type:
+
+    | `tag`           | JavaScript | Python `value` |
+    |-----------------|----------- |----------------|
+    | [kTrueObject]   | `true`     | `True`         |
+    | [kFalseObject]  | `false`    | `False`        |
+    | [kNumberObject] | `number`   | `float`        |
+    | [kBigIntObject] | `bigint`   | `JSBigInt`     |
+    | [kStringObject] | `string`   | `str`          |
+
+    The constructor infers the tag automatically given a value of one of these
+    Python types.
+
+    An `int` `value` is inferred as [kNumberObject] if it's in
+    [FLOAT64_SAFE_INT_RANGE], otherwise [kBigIntObject]. The `int` is converted
+    to `float` or `JSBigInt` according to the inferred `tag`.
+
+    [kTrueObject]: `v8serialize.constants.SerializationTag.kTrueObject`
+    [kFalseObject]: `v8serialize.constants.SerializationTag.kFalseObject`
+    [kNumberObject]: `v8serialize.constants.SerializationTag.kNumberObject`
+    [kBigIntObject]: `v8serialize.constants.SerializationTag.kBigIntObject`
+    [kStringObject]: `v8serialize.constants.SerializationTag.kStringObject`
+    [FLOAT64_SAFE_INT_RANGE]: `v8serialize.constants.FLOAT64_SAFE_INT_RANGE`
+
+    Parameters
+    ----------
+    value:
+        The Python type representing the wrapped JavaScript primitive value.
+    tag:
+        The serialization tag that identifies the type of the wrapped primitive.
+
+        Inferred from the value if `None`.
     """
 
-    value: T
+    value: Final[T_co]  # type: ignore[misc]  # mypy thinks it's uninitialised
     """The primitive value."""
-    tag: PrimitiveObjectTag
+    tag: Final[TagT_co]  # type: ignore[misc]
     """The type of primitive wrapped in this object."""
 
-    def __init__(self, value: T, tag: PrimitiveObjectTag | None = None) -> None:
-        object.__setattr__(self, "value", value)
+    @overload
+    def __init__(
+        self: TrueJSPrimitiveObject,
+        value: Literal[True],
+        tag: Literal[SerializationTag.kTrueObject] | None = None,
+    ) -> None: ...
 
-        expected_tag: PrimitiveObjectTag
-        expected_tag2: PrimitiveObjectTag | None = None
+    @overload
+    def __init__(
+        self: FalseJSPrimitiveObject,
+        value: Literal[False],
+        tag: Literal[SerializationTag.kFalseObject] | None = None,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self: NumberJSPrimitiveObject,
+        value: float,  # also allows int
+        tag: Literal[SerializationTag.kNumberObject],
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self: BigIntJSPrimitiveObject,
+        value: int,
+        tag: Literal[SerializationTag.kBigIntObject],
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self: BigIntJSPrimitiveObject,
+        value: JSBigInt,
+        tag: None = None,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self: NumberJSPrimitiveObject | BigIntJSPrimitiveObject,
+        value: int,
+        tag: None = None,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self: NumberJSPrimitiveObject,
+        value: float,
+        tag: None = None,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self: StringJSPrimitiveObject,
+        value: str,
+        tag: Literal[SerializationTag.kStringObject] | None = None,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self: UnknownJSPrimitiveObject,
+        value: PrimitiveObjectValue | int,
+        tag: None = None,
+    ) -> None: ...
+
+    def __init__(
+        self, value: PrimitiveObjectValue | int, tag: PrimitiveObjectTag | None = None
+    ) -> None:
         if isinstance(value, str):
-            expected_tag = SerializationTag.kStringObject
+            tag = _require_tag(SerializationTag.kStringObject, tag=tag, value=value)
         elif value is True:
-            expected_tag = SerializationTag.kTrueObject
+            tag = _require_tag(SerializationTag.kTrueObject, tag=tag, value=value)
         elif value is False:
-            expected_tag = SerializationTag.kFalseObject
+            tag = _require_tag(SerializationTag.kFalseObject, tag=tag, value=value)
         elif isinstance(value, float):
-            expected_tag = SerializationTag.kNumberObject
+            tag = _require_tag(SerializationTag.kNumberObject, tag=tag, value=value)
+        elif isinstance(value, JSBigInt):
+            tag = _require_tag(SerializationTag.kBigIntObject, tag=tag, value=value)
         elif isinstance(value, int):
-            if value in FLOAT64_SAFE_INT_RANGE:
-                expected_tag = SerializationTag.kNumberObject
-                expected_tag2 = SerializationTag.kBigIntObject
+            # non-specific int values are always cast to a tag-specific type.
+            # Unlike unboxed Number values, NumberObject values are always
+            # serialized as Double (i.e. float64) values, never int types like
+            # Int32.
+            if tag is SerializationTag.kNumberObject:
+                value = float(value)
+            elif tag is SerializationTag.kBigIntObject:
+                value = JSBigInt(value)
             else:
-                expected_tag = SerializationTag.kBigIntObject
+                default_tag: PrimitiveObjectTag = (
+                    SerializationTag.kNumberObject
+                    if value in FLOAT64_SAFE_INT_RANGE
+                    else SerializationTag.kBigIntObject
+                )
+                tag = _require_tag(
+                    SerializationTag.kNumberObject,
+                    SerializationTag.kBigIntObject,
+                    tag=tag,
+                    value=value,
+                    default_tag=default_tag,
+                )
+                value = (
+                    float(value)
+                    if tag is SerializationTag.kNumberObject
+                    else JSBigInt(value)
+                )
         else:
             raise TypeError("value is not a supported primitive type")
 
-        if tag is None:
-            object.__setattr__(self, "tag", expected_tag)
-        elif expected_tag is not tag and expected_tag2 is not tag:
-            if expected_tag2 is not None:
-                msg = f"tag must be {expected_tag} or {expected_tag2}"
-            else:
-                msg = f"tag must be {expected_tag}"
+        assert tag is not None and isinstance(value, (str, bool, float, JSBigInt))
+        object.__setattr__(self, "tag", tag)
+        object.__setattr__(self, "value", value)
 
-            raise ValueError(f"{msg} with value {value!r} of type {type(value)}")
-        else:
-            object.__setattr__(self, "tag", tag)
+
+@overload
+def _require_tag(
+    allowed_tag1: PrimitiveObjectTag,
+    allowed_tag2: PrimitiveObjectTag,
+    /,
+    *,
+    tag: PrimitiveObjectTag | None,
+    value: object,
+    default_tag: PrimitiveObjectTag,
+) -> PrimitiveObjectTag: ...
+
+
+@overload
+def _require_tag(
+    allowed_tag1: PrimitiveObjectTag,
+    /,
+    *,
+    tag: PrimitiveObjectTag | None,
+    value: object,
+) -> PrimitiveObjectTag: ...
+
+
+def _require_tag(
+    *allowed_tags: PrimitiveObjectTag,
+    tag: PrimitiveObjectTag | None,
+    value: object,
+    default_tag: PrimitiveObjectTag | None = None,
+) -> PrimitiveObjectTag:
+    assert len(allowed_tags) > 0
+    if tag is None or tag in allowed_tags:
+        return tag or default_tag or allowed_tags[0]
+    msg = f"tag must be {' or '.join(str(t) for t in allowed_tags)}"
+    raise ValueError(f"{msg} with value {value!r} of type {type(value)}")
+
+
+# fmt: off
+TrueJSPrimitiveObject: TypeAlias =   JSPrimitiveObject[Literal[True],  Literal[SerializationTag.kTrueObject]]    # noqa: E501
+FalseJSPrimitiveObject: TypeAlias =  JSPrimitiveObject[Literal[False], Literal[SerializationTag.kFalseObject]]   # noqa: E501
+NumberJSPrimitiveObject: TypeAlias = JSPrimitiveObject[float,          Literal[SerializationTag.kNumberObject]]  # noqa: E501
+BigIntJSPrimitiveObject: TypeAlias = JSPrimitiveObject[JSBigInt,       Literal[SerializationTag.kBigIntObject]]  # noqa: E501
+StringJSPrimitiveObject: TypeAlias = JSPrimitiveObject[str,            Literal[SerializationTag.kStringObject]]  # noqa: E501
+UnknownJSPrimitiveObject: TypeAlias = Union[
+    TrueJSPrimitiveObject,
+    FalseJSPrimitiveObject,
+    NumberJSPrimitiveObject,
+    BigIntJSPrimitiveObject,
+    StringJSPrimitiveObject
+]
+# fmt: on

--- a/test/jstypes/test_jsbigint.py
+++ b/test/jstypes/test_jsbigint.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import operator
+import sys
+from typing import Any
+
+from test.utils import typeval
+from v8serialize.jstypes.jsbigint import JSBigInt
+
+
+def test_repr() -> None:
+    assert repr(JSBigInt(42)) == "JSBigInt(42)"
+
+
+def test_is_instanceof_int() -> None:
+    assert isinstance(JSBigInt(42), int)
+
+
+def check_int_attr(name: str, *, value: int = 42) -> None:
+    jsbigint = JSBigInt(value)
+    i = int(value)
+    assert typeval(getattr(jsbigint, name)) == (JSBigInt, getattr(i, name))
+
+
+def check_int_method(name: str, *args: Any, value: int = 42) -> None:
+    jsbigint = JSBigInt(value)
+    int_value = int(value)
+
+    expected: int | tuple[int, ...] = getattr(int_value, name)(*args)
+    actual: JSBigInt | tuple[JSBigInt, ...] = getattr(jsbigint, name)(*args)
+
+    if isinstance(expected, tuple):
+        assert isinstance(actual, tuple)
+        assert expected == actual
+        assert set(type(v) for v in actual) == {JSBigInt}
+    else:
+        assert typeval(actual) == (JSBigInt, expected)
+
+
+def test_methods_and_operators_return_JSBigInt() -> None:
+    """All the methods returning int values return JSBigInt."""
+    # Same order as methods defined in JSBigInt
+    check_int_method("as_integer_ratio")
+    check_int_attr("real")
+    check_int_attr("imag")
+    check_int_attr("numerator")
+    check_int_attr("denominator")
+    check_int_method("conjugate")
+    check_int_method("__add__", 2)
+    check_int_method("__sub__", 2)
+    check_int_method("__mul__", 2)
+    check_int_method("__floordiv__", 2)
+    check_int_method("__mod__", 2)
+    check_int_method("__divmod__", 2)
+    check_int_method("__radd__", 2)
+    check_int_method("__rsub__", 2)
+    check_int_method("__rmul__", 2)
+    check_int_method("__rfloordiv__", 2)
+    check_int_method("__rmod__", 2)
+    check_int_method("__rdivmod__", 2)
+    check_int_method("__pow__", 2)
+    check_int_method("__pow__", 2, 100)
+    check_int_method("__rpow__", 2)
+    check_int_method("__rpow__", 2, 100)
+    check_int_method("__and__", 2)
+    check_int_method("__or__", 2)
+    check_int_method("__xor__", 2)
+    check_int_method("__lshift__", 2)
+    check_int_method("__rshift__", 2)
+    check_int_method("__rand__", 2)
+    check_int_method("__ror__", 2)
+    check_int_method("__rxor__", 2)
+    check_int_method("__rlshift__", 2)
+    check_int_method("__rrshift__", 2)
+    check_int_method("__neg__")
+    check_int_method("__pos__")
+    check_int_method("__invert__")
+    check_int_method("__trunc__")
+    check_int_method("__ceil__")
+    check_int_method("__floor__")
+    check_int_method("__round__")
+    check_int_method("__round__", 2)
+    assert typeval(float(JSBigInt(42))) == (float, 42.0)
+    assert typeval(JSBigInt(42).__int__()) == (int, 42)
+    assert typeval(int(JSBigInt(42))) == (int, 42)
+    check_int_method("__abs__")
+    assert typeval(hash(JSBigInt(42))) == (int, 42)
+
+    # Before 3.10 operator.index() returns the instance without calling the
+    # __index__ method, so the type is JSBigInt (we'd rather it was int).
+    # https://github.com/python/cpython/blob/340a82d9cff7127bb5a777d8b9a30b861bb4beee/Objects/abstract.c#L1324
+    if sys.version_info >= (3, 10):
+        assert typeval(operator.index(JSBigInt(42))) == (int, 42)
+    else:
+        assert typeval(operator.index(JSBigInt(42))) == (JSBigInt, 42)
+
+
+def test_types() -> None:
+    # Can assign to int var
+    i: int = JSBigInt(42) + 3
+    # Types reflect that JSBigInt is preserved by operators
+    big: JSBigInt = 4 * JSBigInt(4)
+
+    assert i == 45
+    assert big == 16

--- a/test/jstypes/test_jsprimitiveobject.py
+++ b/test/jstypes/test_jsprimitiveobject.py
@@ -1,0 +1,80 @@
+from typing import Final
+from typing_extensions import assert_type
+
+from v8serialize.constants import FLOAT64_SAFE_INT_RANGE, SerializationTag
+from v8serialize.jstypes import JSPrimitiveObject
+from v8serialize.jstypes.jsbigint import JSBigInt
+from v8serialize.jstypes.jsprimitiveobject import (
+    BigIntJSPrimitiveObject,
+    FalseJSPrimitiveObject,
+    NumberJSPrimitiveObject,
+    StringJSPrimitiveObject,
+    TrueJSPrimitiveObject,
+)
+
+# 2**53 + 2 is an integer that can be represented exactly as a float64, but is
+# outside the limit of sequential integers that float64 can represent.
+# (e.g. float64 cannot represent 2**53 + 1 exactly.)
+UNSAFE_INTEGER_FLOAT: Final = float(2**53 + 2)
+assert int(UNSAFE_INTEGER_FLOAT) == 2**53 + 2
+
+
+def test_init_types() -> None:
+    true_obj = assert_type(JSPrimitiveObject(True), TrueJSPrimitiveObject)
+    assert true_obj.value is True
+    assert true_obj.tag is SerializationTag.kTrueObject
+
+    false_obj = assert_type(JSPrimitiveObject(False), FalseJSPrimitiveObject)
+    assert false_obj.value is False
+    assert false_obj.tag is SerializationTag.kFalseObject
+
+    number_obj = assert_type(JSPrimitiveObject(1.0), NumberJSPrimitiveObject)
+    assert number_obj.value == 1.0
+    assert type(number_obj.value) is float
+    assert number_obj.tag is SerializationTag.kNumberObject
+
+    # int values are mapped to JavaScript Number when in the safe int range,
+    # or JavaScript bigint outside that.
+
+    # mypy doesn't match the ambiguous int overload for some reason, it falls
+    # back to the default typevar bounds.
+    int_bigint_obj = assert_type(  # type: ignore[assert-type]
+        JSPrimitiveObject(FLOAT64_SAFE_INT_RANGE.stop),
+        "NumberJSPrimitiveObject | BigIntJSPrimitiveObject",
+    )
+    assert int_bigint_obj.value == FLOAT64_SAFE_INT_RANGE.stop
+    assert type(int_bigint_obj.value) is JSBigInt
+    assert int_bigint_obj.tag is SerializationTag.kBigIntObject
+
+    # force int as bigint by specifying tag
+    int_bigint_obj2 = assert_type(
+        JSPrimitiveObject(0, tag=SerializationTag.kBigIntObject),
+        BigIntJSPrimitiveObject,
+    )
+    assert int_bigint_obj2.value == 0
+    assert type(int_bigint_obj2.value) is JSBigInt
+    assert int_bigint_obj2.tag is SerializationTag.kBigIntObject
+
+    # mypy doesn't match the ambiguous int overload for some reason
+    int_number_obj = assert_type(  # type: ignore[assert-type]
+        JSPrimitiveObject(FLOAT64_SAFE_INT_RANGE.stop - 1),
+        "NumberJSPrimitiveObject | BigIntJSPrimitiveObject",
+    )
+    assert int_number_obj.value == FLOAT64_SAFE_INT_RANGE.stop - 1
+    assert type(int_number_obj.value) is float
+    assert int_number_obj.tag is SerializationTag.kNumberObject
+
+    # force int as number by specifying tag
+    int_number_obj2 = assert_type(
+        JSPrimitiveObject(
+            int(UNSAFE_INTEGER_FLOAT), tag=SerializationTag.kNumberObject
+        ),
+        NumberJSPrimitiveObject,
+    )
+    assert int_number_obj2.value == UNSAFE_INTEGER_FLOAT
+    assert type(int_number_obj2.value) is float
+    assert int_number_obj2.tag is SerializationTag.kNumberObject
+
+    string_obj = assert_type(JSPrimitiveObject("s"), StringJSPrimitiveObject)
+    assert string_obj.value == "s"
+    assert string_obj.tag is SerializationTag.kStringObject

--- a/test/strategies.py
+++ b/test/strategies.py
@@ -11,6 +11,7 @@ from hypothesis import strategies as st
 
 from v8serialize._values import SharedArrayBufferId, TransferId
 from v8serialize.constants import (
+    FLOAT64_SAFE_INT_RANGE,
     MAX_ARRAY_LENGTH,
     JSErrorName,
     JSRegExpFlag,
@@ -23,6 +24,7 @@ from v8serialize.jstypes._normalise_property_key import normalise_property_key
 from v8serialize.jstypes._v8 import V8SharedObjectReference
 from v8serialize.jstypes.jsarray import JSArray
 from v8serialize.jstypes.jsarrayproperties import JSHole
+from v8serialize.jstypes.jsbigint import JSBigInt
 from v8serialize.jstypes.jsbuffers import (
     ArrayBufferViewStructFormat,
     DataType,
@@ -402,7 +404,22 @@ def js_sets(
     )
 
 
-float_safe_integers = st.integers(min_value=-(2**53 - 1), max_value=2**53 - 1)
+float_safe_integers = st.integers(
+    min_value=FLOAT64_SAFE_INT_RANGE.start, max_value=FLOAT64_SAFE_INT_RANGE.stop - 1
+)
+"""int values in the range of integers that float64 can exactly represent."""
+
+float_unsafe_integers = st.integers(
+    max_value=FLOAT64_SAFE_INT_RANGE.start - 1
+) | st.integers(min_value=FLOAT64_SAFE_INT_RANGE.stop)
+"""int values outside the range of integers that float64 can exactly represent."""
+
+float_unsafe_floats = st.floats(max_value=FLOAT64_SAFE_INT_RANGE.start - 1) | st.floats(
+    min_value=FLOAT64_SAFE_INT_RANGE.stop
+)
+"""float values outside the range of integers that float64 can exactly represent."""
+
+js_big_ints = st.builds(JSBigInt, st.integers())
 
 js_string_objects = st.builds(
     JSPrimitiveObject, value=st.text(), tag=st.just(SerializationTag.kStringObject)
@@ -418,7 +435,7 @@ def js_number_objects(allow_nan: bool = True) -> st.SearchStrategy[int | float]:
 
 
 js_bigint_objects = st.builds(
-    JSPrimitiveObject, value=st.integers(), tag=st.just(SerializationTag.kBigIntObject)
+    JSPrimitiveObject, value=js_big_ints, tag=st.just(SerializationTag.kBigIntObject)
 )
 js_true_objects = st.builds(
     JSPrimitiveObject, value=st.just(True), tag=st.just(SerializationTag.kTrueObject)
@@ -449,6 +466,7 @@ def any_atomic(
         # NaN breaks equality when nested inside objects. We test with nan in
         # test_codec_rt_double.
         st.floats(allow_nan=False),
+        js_big_ints,
         st.text(),
         st.just(JSUndefined),
         st.just(None),

--- a/test/test_codec_round_trip.py
+++ b/test/test_codec_round_trip.py
@@ -9,8 +9,10 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
+from test.utils import typeval
 from v8serialize._pycompat.typing import get_buffer
 from v8serialize.constants import (
+    JS_NUMBER_TAGS,
     JS_PRIMITIVE_OBJECT_TAGS,
     JSErrorName,
     SerializationFeature,
@@ -29,6 +31,7 @@ from v8serialize.jstypes._normalise_property_key import normalise_property_key
 from v8serialize.jstypes._v8 import V8SharedObjectReference
 from v8serialize.jstypes.jsarray import JSArray
 from v8serialize.jstypes.jsarrayproperties import JSHole, JSHoleType
+from v8serialize.jstypes.jsbigint import JSBigInt
 from v8serialize.jstypes.jsbuffers import (
     ArrayBufferViewStructFormat,
     JSArrayBuffer,
@@ -49,8 +52,12 @@ from .strategies import (
     any_atomic,
     any_object,
     dense_js_arrays,
+    float_safe_integers,
+    float_unsafe_floats,
+    float_unsafe_integers,
     js_array_buffer_views,
     js_array_buffers,
+    js_big_ints,
     js_error_data,
     js_maps,
     js_objects,
@@ -181,6 +188,54 @@ def test_codec_rt_uint32(value: int) -> None:
     assert rts.eof
 
 
+@given(value=js_big_ints)
+def test_codec_rt_number_rules__jsbigint_is_bigint(
+    value: JSBigInt, create_rw_ctx: CreateContexts
+) -> None:
+    encode_ctx, decode_ctx = create_rw_ctx()
+    encode_ctx.encode_object(value)
+    decode_ctx.stream.read_tag(consume=False, tag=SerializationTag.kBigInt)
+    result = decode_ctx.decode_object()
+    assert typeval(value) == typeval(result)
+    assert decode_ctx.stream.eof
+
+
+@given(value=float_safe_integers)
+def test_codec_rt_number_rules__float_safe_int_is_int(
+    value: int, create_rw_ctx: CreateContexts
+) -> None:
+    encode_ctx, decode_ctx = create_rw_ctx()
+    encode_ctx.encode_object(value)
+    decode_ctx.stream.read_tag(consume=False, tag=JS_NUMBER_TAGS)
+    result = decode_ctx.decode_object()
+    assert typeval(result) == (int, value)
+    assert decode_ctx.stream.eof
+
+
+@given(value=float_unsafe_integers)
+def test_codec_rt_number_rules__float_unsafe_int_is_bigint(
+    value: int, create_rw_ctx: CreateContexts
+) -> None:
+    encode_ctx, decode_ctx = create_rw_ctx()
+    encode_ctx.encode_object(value)
+    decode_ctx.stream.read_tag(consume=False, tag=SerializationTag.kBigInt)
+    result = decode_ctx.decode_object()
+    assert typeval(result) == (JSBigInt, value)
+    assert decode_ctx.stream.eof
+
+
+@given(value=float_unsafe_floats)
+def test_codec_rt_number_rules__float_unsafe_float_is_float(
+    value: float, create_rw_ctx: CreateContexts
+) -> None:
+    encode_ctx, decode_ctx = create_rw_ctx()
+    encode_ctx.encode_object(value)
+    decode_ctx.stream.read_tag(consume=False, tag=SerializationTag.kDouble)
+    result = decode_ctx.decode_object()
+    assert typeval(result) == (float, value)
+    assert decode_ctx.stream.eof
+
+
 all_constants = st.sampled_from([JSHole, JSUndefined, None, True, False])
 """JS Constant values, including JSHole."""
 
@@ -197,8 +252,16 @@ def test_codec_rt_constants(
     assert decode_ctx.stream.eof
 
 
-@given(st.one_of(st.booleans(), st.text(), st.floats(allow_nan=False), st.integers()))
-def test_codec_rt_primitive_object(value: bool | str | float | int) -> None:
+@given(
+    st.one_of(
+        st.booleans(),
+        st.text(),
+        st.floats(allow_nan=False),
+        st.integers(),
+        js_big_ints,
+    )
+)
+def test_codec_rt_primitive_object(value: bool | str | float | int | JSBigInt) -> None:
     wrapped = JSPrimitiveObject(value)
     wts = WritableTagStream()
     wts.write_js_primitive_object(wrapped)
@@ -206,6 +269,7 @@ def test_codec_rt_primitive_object(value: bool | str | float | int) -> None:
     assert rts.read_tag(consume=False, tag=JS_PRIMITIVE_OBJECT_TAGS)
     serialized_id, result = rts.read_js_primitive_object()
     assert result == wrapped
+    assert type(result.value) is type(wrapped.value)
     assert rts.eof
 
 

--- a/test/test_encode.py
+++ b/test/test_encode.py
@@ -6,9 +6,14 @@ from datetime import datetime
 import pytest
 from packaging.version import Version
 
+from test.utils import typeval
 from v8serialize._pycompat.exceptions import has_notes
 from v8serialize._references import IllegalCyclicReferenceV8SerializeError
-from v8serialize.constants import JSRegExpFlag, SerializationFeature
+from v8serialize.constants import (
+    FLOAT64_SAFE_INT_RANGE,
+    JSRegExpFlag,
+    SerializationFeature,
+)
 from v8serialize.decode import loads
 from v8serialize.encode import (
     DefaultEncodeContext,
@@ -22,6 +27,7 @@ from v8serialize.encode import (
 )
 from v8serialize.jstypes import JSRegExp
 from v8serialize.jstypes.jsarray import JSArray
+from v8serialize.jstypes.jsbigint import JSBigInt
 from v8serialize.jstypes.jsbuffers import JSArrayBuffer, JSFloat16Array
 from v8serialize.jstypes.jserror import JSError
 from v8serialize.jstypes.jsmap import JSMap
@@ -35,7 +41,11 @@ from v8serialize.jstypes.jsundefined import JSUndefined
     [
         (1, 1),
         (1.5, 1.5),
-        (2**100, 2**100),
+        (FLOAT64_SAFE_INT_RANGE.stop - 1, FLOAT64_SAFE_INT_RANGE.stop - 1),
+        (float(FLOAT64_SAFE_INT_RANGE.stop - 1), FLOAT64_SAFE_INT_RANGE.stop - 1),
+        (FLOAT64_SAFE_INT_RANGE.stop, JSBigInt(FLOAT64_SAFE_INT_RANGE.stop)),
+        (JSBigInt(1), JSBigInt(1)),
+        (2**100, JSBigInt(2**100)),
         (True, True),
         (False, False),
         (None, None),
@@ -68,7 +78,7 @@ def test_python_collections(py_value: object, js_value: object) -> None:
     serialized = dumps(py_value)
     deserialized = loads(serialized)
 
-    assert deserialized == js_value
+    assert typeval(deserialized) == typeval(js_value)
 
 
 def test_feature_float16__cannot_write_float16array_when_disabled() -> None:


### PR DESCRIPTION
This PR adds the `JSBigInt` type — a Python `int` subclass that always encodes to BigInt.

It also adjusts the number encoding rules.

  - The JSBigInt type added in this release always encodes to JavaScript bigint,
    and serialized bigints always decode to JSBigInt.
    - Previously bigint decoded to plain `int`, which meant that bigints in the
      safe float range would not round-trip as bigint, they'd be encoded as one
      of the int types, like Int32, or Double.
  - JavaScript Numbers encoded as Double (float64) now decode to Python `int` if
    they are exact integers in the range of integers that float64 can represent
    exactly.
    - Previously JavaScript Numbers that weren't serialized as one of the int
      types (like Int32) were always decoded as Python `float`.

  The encoding rules now are:

  - Python `float` always encodes to Double/float64.
  - Python `int` encodes to Double/float64 if it's within the float-safe range
    but too large for the int types, like Int32.
  - Python `int` encodes to JavaScript bigint if it's outside than the
    float-safe range.
  - Python `JSBigInt` always encodes to JavaScript bigint.

  The decoding rules now are:

  - JavaScript Double/float64 decodes to Python `float`, unless it's an exact
    integer within the float-safe integer range, in which case it decodes as
    Python `int`.
  - Small int values like Int32 decode as Python `int`.
  - JavaScript bigint values decode as Python `JSBigInt`.

  So values round-trip with the same types consistently, with the exceptions of:

  - large Python `int` which becomes `JSBigInt` after a round-trip.
  - exact integer Python `float` round-trip to Python `int`
    - This is compatible with Python's numeric type system as `int` types are
      accepted by types requiring `float`, and the `/` and `//` operators work
      equivalently with `int` and `float` representations of the same value.