### PR TITLE
Fix encoding/decoding of primitive string objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,65 @@ and this project adheres to
 
 ## [Unreleased]
 
+> [!IMPORTANT]
+>
+> This version made some backwards-incompatible changes, but they are not likely
+> to affect typical users, unless they're explicitly creating and persisting
+> `JSPrimitiveObject` or customising decoding.
+
+<details>
+<summary><h3>Backwards-incompatible changes<h3></summary>
+
+#### Encoding/decoding primitive string objects
+
+The encoding/decoding of primitive string objects was incorrect in 0.1.0 and has
+changed to match the current V8 serialisation format (see the fixed section).
+The backwards compatibility impact of this is that `JSPrimitiveObject` values
+containing strings serialized by `v8serialize` in 0.1.0 are not deserializable
+in this version.
+
+These objects are not created by default, so to be affected, code would need to
+have explicitly created and serialised instances and persisted the serialised
+representation to be loaded by this version.
+
+Instances of this value sent to or received from real V8 implementations are not
+affected in a backwards-incompatible way, as values would fail to decode in
+either direction because of the mutually-incompatible encoding.
+
+#### API changes
+
+The `v8serialize.decode.ReadableTagStream.read_js_primitive_object` method now
+requires a `ctx: DecodeContext` argument, as many other methods on this type do.
+This was required to fix [#8].
+
+</details>
+
+[#8]: https://github.com/h4l/v8serialize/issues/8
+
+### Fixed
+
+- [Wrapped/boxed string values][MDN Primitive] (JavaScript `new String("x")` /
+  Python `JSPrimitiveObject("x")`, (used to distinguish `new String("x")` from
+  `"x"`)) are now encoded/decoded correctly. Previously they were incorrectly
+  being encoded/decoded using an obsolete version of the V8 serialization
+  format, earlier than the currently-used format, and earlier than the minimum
+  version `v8serialize` supports. ([#8])
+
+### Added
+
+- Support for round-tripping wrapped/boxed JavaScript primitive type objects.
+
+  The `loads()` function and `TagReader` class now take a `js_primitive_objects`
+  bool option (defaulting `False`) that uses `JSPrimitiveObject` values in
+  decoded values rather than their unwrapped primitive value.
+
+[MDN Primitive]: https://developer.mozilla.org/en-US/docs/Glossary/Primitive
+
+## [0.2.0-alpha.0] - 2024-12-30
+
+I never tagged & published a stable release of this alpha release, I forgot as I
+was installing the project from git and then working on other things, sorry!
+
 ### Added
 
 - Marked SerializationFeature.Float16Array as released from V8 13.1.201 (was
@@ -59,8 +118,7 @@ and this project adheres to
     - This is compatible with Python's numeric type system as `int` types are
       accepted by types requiring `float`, and the `/` and `//` operators work
       equivalently with `int` and `float` representations of the same value.
-
-  ([#7](https://github.com/h4l/v8serialize/pull/7))
+      ([#7](https://github.com/h4l/v8serialize/pull/7))
 
 ## [0.1.0] - 2024-09-24
 
@@ -70,3 +128,4 @@ and this project adheres to
 
 [unreleased]: https://github.com/h4l/v8serialize/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/h4l/v8serialize/releases/tag/v0.1.0
+[0.2.0-alpha.0]: https://github.com/h4l/v8serialize/releases/tag/v0.2.0-alpha.0

--- a/src/v8serialize/decode.py
+++ b/src/v8serialize/decode.py
@@ -1123,6 +1123,7 @@ class TagReader(DecodeStepObject):
     [JSError.builder]: `v8serialize.jstypes.JSError.builder`
     [datetime]: `datetime.datetime`
     [desc]: `v8serialize.loads`
+    [JSPrimitiveObject]: `v8serialize.jstypes.JSPrimitiveObject`
 
     Parameters
     ----------
@@ -1140,6 +1141,10 @@ class TagReader(DecodeStepObject):
     js_constants
         A dict mapping tags from [JS_CONSTANT_TAGS] to the values to represent
         them as. Default: see [JS_CONSTANT_TAGS].
+    js_primitive_objects
+        If `True`, wrapped/boxed primitive values are decoded as
+        [JSPrimitiveObject]. If `False`, wrapped/boxed primitives are unwrapped
+        to native Python types. Default: `False`.
     host_object_deserializer
         A [HostObjectDeserializer] to load [HostObject] extension tags.
         Default: see [desc].
@@ -1156,6 +1161,7 @@ class TagReader(DecodeStepObject):
     js_object_type: JSObjectType
     js_array_type: JSArrayType
     js_constants: Mapping[ConstantTags, object]
+    js_primitive_objects: bool
     host_object_deserializer: HostObjectDeserializer[object] | None
     js_error_builder: JSErrorBuilder[object]
     default_timezone: tzinfo | None
@@ -1168,6 +1174,7 @@ class TagReader(DecodeStepObject):
         js_object_type: JSObjectType | None = None,
         js_array_type: JSArrayType | None = None,
         js_constants: Mapping[ConstantTags, object] | None = None,
+        js_primitive_objects: bool | None = None,
         host_object_deserializer: HostObjectDeserializer[object] | None = None,
         js_error_builder: JSErrorBuilder[object] | None = None,
         default_timezone: tzinfo | None = None,
@@ -1176,6 +1183,7 @@ class TagReader(DecodeStepObject):
         self.jsset_type = jsset_type or JSSet
         self.js_object_type = js_object_type or JSObject
         self.js_array_type = js_array_type or JSArray
+        self.js_primitive_objects = bool(js_primitive_objects)
         self.host_object_deserializer = host_object_deserializer
         self.js_error_builder = js_error_builder or JSError.builder
         self.default_timezone = default_timezone
@@ -1379,6 +1387,10 @@ class TagReader(DecodeStepObject):
         self, tag: PrimitiveObjectTag, ctx: DecodeContext
     ) -> object:
         serialized_id, obj = ctx.stream.read_js_primitive_object(tag)
+
+        if self.js_primitive_objects:
+            return obj
+
         # Unwrap objects so they act like regular strings/numbers/bools.
         # (Alternatively, we could make the wrapper types subclasses of their
         # wrapped value type and keep the wrapper.)
@@ -1536,6 +1548,7 @@ def loads(
     js_object_type: JSObjectType | None = None,
     js_array_type: JSArrayType | None = None,
     js_constants: Mapping[ConstantTags, object] | None = None,
+    js_primitive_objects: bool | None = None,
     host_object_deserializer: HostObjectDeserializer[object] | None = None,
     js_error_builder: JSErrorBuilder[object] | None = None,
     default_timezone: tzinfo | None = None,
@@ -1552,6 +1565,7 @@ def loads(
     js_object_type: JSObjectType | None = None,
     js_array_type: JSArrayType | None = None,
     js_constants: Mapping[ConstantTags, object] | None = None,
+    js_primitive_objects: bool | None = None,
     host_object_deserializer: HostObjectDeserializer[object] | None = None,
     js_error_builder: JSErrorBuilder[object] | None = None,
     default_timezone: tzinfo | None = None,
@@ -1586,6 +1600,7 @@ def loads(
     [JSError.builder]: `v8serialize.jstypes.JSError.builder`
     [datetime]: `datetime.datetime`
     [desc]: `v8serialize.loads`
+    [JSPrimitiveObject]: `v8serialize.jstypes.JSPrimitiveObject`
 
     Parameters
     ----------
@@ -1609,6 +1624,10 @@ def loads(
     js_constants
         A dict mapping tags from [JS_CONSTANT_TAGS] to the values to represent
         them as. Default: see [JS_CONSTANT_TAGS].
+    js_primitive_objects
+        If `True`, wrapped/boxed primitive values are decoded as
+        [JSPrimitiveObject]. If `False`, wrapped/boxed primitives are unwrapped
+        to native Python types. Default: `False`.
     host_object_deserializer
         A [HostObjectDeserializer] to load [HostObject] extension tags.
         Default: see [desc].
@@ -1683,6 +1702,7 @@ def loads(
             and js_object_type is None
             and js_array_type is None
             and js_constants is None
+            and js_primitive_objects is None
             and host_object_deserializer is None
             and js_error_builder is None
             and default_timezone is None
@@ -1708,6 +1728,7 @@ def loads(
         js_object_type=js_object_type,
         js_array_type=js_array_type,
         js_constants=js_constants,
+        js_primitive_objects=js_primitive_objects,
         host_object_deserializer=host_object_deserializer,
         js_error_builder=js_error_builder,
         default_timezone=default_timezone,

--- a/src/v8serialize/decode.py
+++ b/src/v8serialize/decode.py
@@ -377,7 +377,7 @@ class ReadableTagStream:
         self.throw(f"Serialized value is out of {UINT32_RANGE} for UInt32: {value}")
 
     def read_js_primitive_object(
-        self, tag: PrimitiveObjectTag | None = None
+        self, ctx: DecodeContext, *, tag: PrimitiveObjectTag | None = None
     ) -> tuple[SerializedId, JSPrimitiveObject]:
         if tag and tag not in JS_PRIMITIVE_OBJECT_TAGS:
             raise ValueError("tag must be a primitive object tag")
@@ -397,7 +397,9 @@ class ReadableTagStream:
                 tag=SerializationTag.kBigIntObject,
             )
         elif tag is SerializationTag.kStringObject:
-            result = JSPrimitiveObject(self.read_string_utf8(tag=False))
+            value = ctx.decode_object(tag=self.read_tag(tag=JS_STRING_TAGS))
+            assert isinstance(value, str)
+            result = JSPrimitiveObject(value)
         else:
             raise AssertionError(f"Unreachable: {tag}")
         return self.objects.record_reference(result), result
@@ -1386,7 +1388,7 @@ class TagReader(DecodeStepObject):
     def deserialize_js_primitive_object(
         self, tag: PrimitiveObjectTag, ctx: DecodeContext
     ) -> object:
-        serialized_id, obj = ctx.stream.read_js_primitive_object(tag)
+        serialized_id, obj = ctx.stream.read_js_primitive_object(ctx, tag=tag)
 
         if self.js_primitive_objects:
             return obj

--- a/src/v8serialize/encode.py
+++ b/src/v8serialize/encode.py
@@ -367,7 +367,9 @@ class WritableTagStream:
         self.write_tag(tag)
         if tag is SerializationTag.kStringObject:
             assert isinstance(value, str)
-            self.write_string_utf8(value, tag=None)
+            # We can write any of the string formats here, but just UTF-8
+            # seems fine.
+            self.write_string_utf8(value)
         elif (
             tag is SerializationTag.kTrueObject or tag is SerializationTag.kFalseObject
         ):

--- a/src/v8serialize/jstypes/jsprimitiveobject.py
+++ b/src/v8serialize/jstypes/jsprimitiveobject.py
@@ -46,6 +46,9 @@ class JSPrimitiveObject(Generic[T_co, TagT_co], metaclass=ABCMeta):
     :::{.callout-tip}
     This is a low-level type that won't occur in decoded data by default, and
     can be ignored.
+
+    If you *do* want it to occur in decoded data, pass the
+    `js_primitive_objects=True` option to [`loads()`] or [`TagReader`].
     :::
 
     JavaScript primitives like `string` and `number` have object wrapper types
@@ -64,6 +67,7 @@ class JSPrimitiveObject(Generic[T_co, TagT_co], metaclass=ABCMeta):
         times in a V8 serialized data stream. This could be used to de-duplicate
         strings or bigints.
     * It allows data streams to be round-tripped exactly.
+
 
     ---
     Each `tag` has a single `value` type:
@@ -89,6 +93,8 @@ class JSPrimitiveObject(Generic[T_co, TagT_co], metaclass=ABCMeta):
     [kBigIntObject]: `v8serialize.constants.SerializationTag.kBigIntObject`
     [kStringObject]: `v8serialize.constants.SerializationTag.kStringObject`
     [FLOAT64_SAFE_INT_RANGE]: `v8serialize.constants.FLOAT64_SAFE_INT_RANGE`
+    [`loads()`]: `v8serialize.decode.loads`
+    [`TagReader`]: `v8serialize.decode.TagReader`
 
     Parameters
     ----------

--- a/test/strategies.py
+++ b/test/strategies.py
@@ -477,6 +477,7 @@ def any_atomic(
             allow_linear=allow_theoretical,
             allow_unicode_sets=SerializationFeature.RegExpUnicodeSets in features,
         ),
+        js_primitive_objects(allow_nan=False),
         # Use naive datetimes for general tests to avoid needing to normalise tz.
         # (Can't serialize tz, so aware datetimes come back as naive or a fixed tz;
         # epoch timestamp always matches though.)

--- a/test/test_codec_round_trip.py
+++ b/test/test_codec_round_trip.py
@@ -85,7 +85,11 @@ def create_rw_ctx() -> CreateContexts:
             stream=WritableTagStream(features=~SerializationFeature.MaxCompatibility),
         )
         decode_ctx = DefaultDecodeContext(
-            data=encode_ctx.stream.data, decode_steps=[TagReader()]
+            data=encode_ctx.stream.data,
+            # We keep wrapped primitive objects in the output, otherwise values
+            # don't round-trip exactly, as we'd compare pre-encode wrapped
+            # primitives to post-encode unwrapped primitives.
+            decode_steps=[TagReader(js_primitive_objects=True)],
         )
         return encode_ctx, decode_ctx
 
@@ -253,7 +257,7 @@ def test_codec_rt_constants(
 
 
 @given(
-    st.one_of(
+    value=st.one_of(
         st.booleans(),
         st.text(),
         st.floats(allow_nan=False),
@@ -261,16 +265,17 @@ def test_codec_rt_constants(
         js_big_ints,
     )
 )
-def test_codec_rt_primitive_object(value: bool | str | float | int | JSBigInt) -> None:
+def test_codec_rt_primitive_object(
+    value: bool | str | float | int | JSBigInt, create_rw_ctx: CreateContexts
+) -> None:
+    encode_ctx, decode_ctx = create_rw_ctx()
     wrapped = JSPrimitiveObject(value)
-    wts = WritableTagStream()
-    wts.write_js_primitive_object(wrapped)
-    rts = ReadableTagStream(wts.data)
-    assert rts.read_tag(consume=False, tag=JS_PRIMITIVE_OBJECT_TAGS)
-    serialized_id, result = rts.read_js_primitive_object()
+    encode_ctx.stream.write_js_primitive_object(wrapped)
+    assert decode_ctx.stream.read_tag(consume=False, tag=JS_PRIMITIVE_OBJECT_TAGS)
+    serialized_id, result = decode_ctx.stream.read_js_primitive_object(decode_ctx)
     assert result == wrapped
     assert type(result.value) is type(wrapped.value)
-    assert rts.eof
+    assert decode_ctx.stream.eof
 
 
 @given(value=naive_timestamp_datetimes)

--- a/test/test_decode.py
+++ b/test/test_decode.py
@@ -113,6 +113,16 @@ def test_loads_options__tagreader() -> None:
     assert type(jsmap) is JSMap
 
 
+def test_loads_options__js_primitive_objects() -> None:
+    string_obj = JSPrimitiveObject("foo")
+    assert string_obj != "foo"  # type: ignore[comparison-overlap]
+
+    assert loads(dumps(string_obj), js_primitive_objects=True) == string_obj
+    assert loads(dumps(string_obj), js_primitive_objects=False) == "foo"
+    assert loads(dumps(string_obj), js_primitive_objects=None) == "foo"
+    assert loads(dumps(string_obj)) == "foo"
+
+
 def test_load_v13_arraybufferview() -> None:
     # Format v13 is the oldest version it makes sense to support, introduced in
     # 2017 and used in Node.js 16. It serializes ArrayBufferView without flags

--- a/test/test_decode.py
+++ b/test/test_decode.py
@@ -28,6 +28,7 @@ from v8serialize.jstypes.jsarray import JSArray
 from v8serialize.jstypes.jsbuffers import JSArrayBuffer, JSUint8Array, JSUint32Array
 from v8serialize.jstypes.jserror import JSError, JSErrorData
 from v8serialize.jstypes.jsmap import JSMap
+from v8serialize.jstypes.jsprimitiveobject import JSPrimitiveObject
 
 
 @given(st.integers(min_value=1))
@@ -52,6 +53,10 @@ def test_decode_varint__truncated(n: int) -> None:
         # s = new Set([1]); v8.serialize(new Map([['a', s], ['b', s]]))
         #   .toString('base64')
         ("/w87IgFhJ0kCLAEiAWJeAToE", {"a": {1}, "b": {1}}),  # TODO: verify identity
+        # v8.serialize([new String("📦")]).toString("base64")
+        # We were decoding wrapped primitive object strings incorrectly, see:
+        # https://github.com/h4l/v8serialize/issues/8
+        ("/w9BAXMAYwQ92ObcJAAB", JSArray(["📦"])),
     ],
 )
 def test_loads(serialized: str, expected: object) -> None:

--- a/test/test_round_trip_with_v8.py
+++ b/test/test_round_trip_with_v8.py
@@ -364,7 +364,13 @@ def enabled_features(
 # TODO: also test with serialize_object_references (default_encode_steps)
 encode_steps = [TagWriter()]
 decode_steps: Sequence[DecodeStep] = [
-    TagReader(host_object_deserializer=NodeJsArrayBufferViewHostObjectHandler())
+    TagReader(
+        host_object_deserializer=NodeJsArrayBufferViewHostObjectHandler(),
+        # We keep wrapped primitive objects in the output, otherwise values
+        # don't round-trip exactly, as we'd compare pre-encode wrapped
+        # primitives to post-encode unwrapped primitives.
+        js_primitive_objects=True,
+    )
 ]
 
 


### PR DESCRIPTION
This fixes #8.

This MR fixes the encoding/decoding of wrapped/boxed string values (JavaScript `new String("x")` / Python
  `JSPrimitiveObject("x")`). They were mistakenly using an older representation of the V8 serialization format, which stored them as raw length-prefixed UTF-8 values without the normal `SerializationTag.kUtf8String`. This was used before version 12 of the format, which we don't support. This resulted in wrapped strings failing to decode when received from a real V8 implementation, and equally ours would fail to be decoded by V8.

The automated integration tests which round-trip through several external implementations of the format failed to detect the error, because the property test scenarios generating examples to verify were mistakenly not generating wrapped primitive objects.

We now use the correct, current encoding and include wrapped primitive objects in the round-trip integration tests.

The API also gained a new feature, to allow wrapped primitive objects to be retained in decoded values. This is disabled by default, but necessary to round-trip values containing wrapped primitive objects.