### PR TITLE
chore: add vscode devcontainer config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,36 @@
+ARG QUARTO_VERSION=1.8.24
+
+
+FROM scratch AS quarto-linux-deb
+ARG QUARTO_VERSION TARGETARCH
+
+# URL from # https://quarto.org/docs/download/
+ADD https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION:?}/quarto-${QUARTO_VERSION:?}-linux-${TARGETARCH:?}.deb .
+
+
+FROM scratch AS deno-install-sh
+ADD https://deno.land/install.sh .
+
+
+FROM mcr.microsoft.com/devcontainers/python:3.12-bookworm AS devcontainer-base
+ENV DENO_INSTALL=/opt/deno
+
+
+FROM devcontainer-base AS devcontainer-deno
+
+RUN --mount=from=deno-install-sh,source=install.sh,target=/tmp/install.sh \
+  sh /tmp/install.sh --yes --no-modify-path
+
+
+FROM devcontainer-base AS devcontainer
+
+# We use direnv to dynamically set envars for docker compose
+RUN apt-get update && apt-get install direnv \
+  && printf '\n%s\n' 'eval "$(direnv hook bash)"' >> /etc/bash.bashrc
+
+# Install quarto, which we use to build the documentation. Quarto is an
+# open-source scientific and technical publishing system built on Pandoc.
+RUN --mount=from=quarto-linux-deb,target=/debfiles dpkg -i /debfiles/quarto-*.deb
+
+ENV PATH=${PATH:?}:${DENO_INSTALL:?}/bin
+COPY --chown=vscode:vscode --from=devcontainer-deno ${DENO_INSTALL:?} ${DENO_INSTALL:?}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,47 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+  "name": "v8serialize",
+  "build": {
+    "target": "devcontainer",
+    "dockerfile": "./Dockerfile"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+  },
+  "containerEnv": {
+    "V8SERIALIZE_NETWORK_EXTERNAL": "true",
+    "V8SERIALIZE_NETWORK": "devcontainer_v8serialize"
+  },
+  "initializeCommand": "V8SERIALIZE_NETWORK=devcontainer_v8serialize; { docker network inspect \"${V8SERIALIZE_NETWORK:?}\" > /dev/null 2>&1 && echo \"Network '${V8SERIALIZE_NETWORK:?}' exists\"; } || docker network create \"${V8SERIALIZE_NETWORK:?}\"",
+  "runArgs": ["--network=devcontainer_v8serialize"],
+  "postCreateCommand": "pipx install poetry",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "charliermarsh.ruff",
+        "denoland.vscode-deno",
+        "esbenp.prettier-vscode",
+        "hashicorp.hcl",
+        "ms-python.mypy-type-checker",
+        "ms-python.python"
+      ],
+      "settings": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "[jsonc]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff",
+          "editor.formatOnSave": true
+        },
+        "python.testing.pytestArgs": ["."],
+        "python.testing.unittestEnabled": false,
+        "python.testing.pytestEnabled": true,
+        "python.analysis.typeCheckingMode": "off",
+        "deno.enable": true,
+        "deno.enablePaths": ["./testing/v8serialize-echo/"]
+      }
+    }
+  }
+}

--- a/.envrc
+++ b/.envrc
@@ -30,4 +30,7 @@ if [[ "${V8SERIALIZE_DEVCONTAINER_VOLUME?}" ]]; then
   export V8SERIALIZE_DEVCONTAINER_VOLUME
   export WORKSPACE_MOUNT_PATH=/workspaces
   export "COMPOSE_FILE=$(pwd)/docker-compose.yml:$(pwd)/docker-compose.devcontainer.yml"
+elif [[ ${CODESPACES:-} == true ]]; then
+  export WORKSPACE_MOUNT_PATH=/workspaces
+  export "COMPOSE_FILE=$(pwd)/docker-compose.yml:$(pwd)/docker-compose.devcontainer-codespaces.yml"
 fi

--- a/docker-compose.devcontainer-codespaces.yml
+++ b/docker-compose.devcontainer-codespaces.yml
@@ -1,0 +1,5 @@
+services:
+  integration_test:
+    volumes:
+      - "/var/lib/docker/codespacemount/workspace:${WORKSPACE_MOUNT_PATH:?}"
+    working_dir: $PWD


### PR DESCRIPTION
This is the devcontainer config I use to work on the project. It has some config to allow the docker compose config to interoperate with the devcontainer container, by putting the devcontainer on the same docker network as the compose config, and mounting the devcontainer's workspace volume into the `integration_test` service. 

It also also supports GitHub codespaces, which are quite similar to devcontainers.